### PR TITLE
fix (#26): When clicking on scrollbar for long menu list, don't trigger closing the dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@politico/vue-accessible-selects",
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@politico/vue-accessible-selects",
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "description": "Select & Multi Select implementations for Vue, focused especially on implementing accessibility best practices",
   "files": [
     "dist",

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -144,7 +144,6 @@
 			},
 
 			onInputBlur() {
-				console.log('calling onInputBlur', this.ignoreBlur)
 				if (this.ignoreBlur) {
 					this.ignoreBlur = false
 					return

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -144,6 +144,7 @@
 			},
 
 			onInputBlur() {
+				console.log('calling onInputBlur', this.ignoreBlur)
 				if (this.ignoreBlur) {
 					this.ignoreBlur = false
 					return
@@ -161,9 +162,14 @@
 				this.updateOption(index)
 			},
 
-			onOptionMouseDown() {
+			onOptionMouseDown(event: MouseEvent) {
 				this.ignoreBlur = true
 				this.callFocus = true
+				event.stopPropagation()
+			},
+
+			onMenuMouseDown(event: MouseEvent) {
+				event.preventDefault()
 			},
 
 			removeOption(index: number) {
@@ -243,6 +249,7 @@
 				class="combo-menu"
 				role="listbox"
 				aria-multiselectable="true"
+				@mousedown="onMenuMouseDown"
 			>
 				<div
 					v-for="(option, index) in filteredOptions"

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -173,8 +173,12 @@
 				this.onOptionChange(index)
 				this.updateMenuState(false)
 			},
-			onOptionMouseDown() {
+			onOptionMouseDown(event: MouseEvent) {
 				this.ignoreBlur = true
+				event.stopPropagation()
+			},
+			onMenuMouseDown(event: MouseEvent) {
+				event.preventDefault()
 			},
 			onOptionChange(index: number) {
 				this.activeIndex = index
@@ -219,7 +223,13 @@
 			</span>
 		</div>
 		<!-- tabindex -->
-		<div :id="`${htmlId}-listbox`" ref="listboxEl" class="combo-menu" role="listbox">
+		<div 
+			:id="`${htmlId}-listbox`" 
+			ref="listboxEl" 
+			class="combo-menu" 
+			role="listbox"
+			@mousedown="onMenuMouseDown"
+		>
 			<div
 				v-for="(option, index) in options"
 				:id="`${htmlId}-item-${index}`"


### PR DESCRIPTION
In our Politico applications, we find that clicking on the scrollbar of a menu 'counts' as clicking outside the `<input>`,
thus triggering an attempted blur event for the <input>
However, that means that the state would become closed for the select, and the select would close
To fix this, we ensure that:
1) The handling for clicking an option remains the same, but we turn off event propagation - don't bubble that up to count as an event click on the menu overall
2) When there's a click on the menu overall (because we've disabled propagation from options, this is pretty much only the scrollbar), do `preventDefault()` - this will prevent the event from triggering a `blur` of the `<input>`