### PR TITLE
docs: Use HTML tags to demo custom slots

### DIFF
--- a/docs/SelectMultiWithCustomOptions.stories.ts
+++ b/docs/SelectMultiWithCustomOptions.stories.ts
@@ -24,10 +24,10 @@ const Template = (args, { argTypes }) => ({
 			:displayPillsBelowInput="displayPillsBelowInput"
 			>
 				<template v-slot:selectedOption="{ option }" >
-					[{{ option.label }}] [{{ option.value }}]
+					<strong>{{ option.label }}</strong> <em>{{ option.value }}</em>
 				</template>
 				<template v-slot:option="{ option }" >
-					[label]: {{ option.label }} [with value]: {{ option.value }}
+					<strong>label: {{ option.label }}<strong>, <em>with value: {{ option.value }}</em>
 				</template>
 		</SelectMulti>
 	</div>`

--- a/docs/SelectSingleWithCustomOptions.stories.ts
+++ b/docs/SelectSingleWithCustomOptions.stories.ts
@@ -28,10 +28,10 @@ const Template = (args, { argTypes }) => ({
 			:disabled="disabled"
 		>
 			<template v-slot:selectedOption="{ option }" >
-				[{{ option.label }}] [{{ option.value }}]
+				<strong>{{ option.label }}</strong> <em>{{ option.value }}</em>
 			</template>
 			<template v-slot:option="{ option }" >
-				[label]: {{ option.label }} [with value]: {{ option.value }}
+				<strong>label: {{ option.label }}</strong>, <em>with value: {{ option.value }}</em>
 			</template>
 		</SelectSingle>
 	</div>`


### PR DESCRIPTION
Rather than `[]`, which at first glance looks a little like a rendering bug, and we just want to demo primarily that you can write whatever you want in there, including HTML