### PR TITLE
feature (#38): Add optional no results msg

### DIFF
--- a/docs/SelectMulti.stories.ts
+++ b/docs/SelectMulti.stories.ts
@@ -22,6 +22,7 @@ const Template = (args, { argTypes }) => ({
 			:placeholder="placeholder"
 			:disabled="disabled"
 			:displayPillsBelowInput="displayPillsBelowInput"
+			:noResultsMessage="noResultsMessage"
 	  	/>
 	</div>`
 });
@@ -34,6 +35,7 @@ Primary.args = {
 	placeholder: 'Select Options',
 	disabled: false,
 	displayPillsBelowInput: false,
+	noResultsMessage: ''
 };
 
 
@@ -59,7 +61,8 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 			:placeholder="placeholder"
 			:disabled="disabled"
 			:displayPillsBelowInput="displayPillsBelowInput"
-			>
+			:noResultsMessage="noResultsMessage"
+		>
 				<template v-slot:selectedOption="{ option }" >
 					<strong>{{ option.label }}</strong> <em>{{ option.value }}</em>
 				</template>
@@ -78,6 +81,7 @@ WithCustomOptions.args = {
 	placeholder: 'Select Options',
 	disabled: false,
 	displayPillsBelowInput: false,
+	noResultsMessage: ''
 };
 
 WithCustomOptions.story = {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
+    "start": "npm run storybook",
     "test": "echo \"TODO: write basic specs\"",
     "build": "rm -rf dist && rm -rf styles && NODE_ENV=production rollup --config rollup.config.js",
     "prepublishOnly": "npm test && npm run build && npm run shake",

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -154,11 +154,20 @@
 					this.$emit('searchChange', this.inputValue)
 				}
 
-				this.notificationMessage = !this.filteredOptions.length ? 'no results found' : ''
+				this.determineMenuStateAndNotificationMessage()
+			},
+			determineMenuStateAndNotificationMessage() {
+				let newMenuState = true
+				this.notificationMessage = ''
 
-				const menuState = this.filteredOptions.length > 0 || this.noResultsMessage
-				if (this.open !== menuState) {
-					this.updateMenuState(menuState, false)
+				if (!this.filteredOptions.length) {
+					// if there are no filteredOptions, the menu should only remain open when a custom `noResultsMessage` has been provided
+					newMenuState = !!this.noResultsMessage
+					this.notificationMessage = this.noResultsMessage || 'no results found'
+				}
+
+				if (this.open !== newMenuState) {
+					this.updateMenuState(newMenuState, false)
 				}
 			},
 			onInputKeyDown(event: KeyboardEvent) {

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -83,6 +83,15 @@
 				type: Boolean,
 				default: false
 			},
+			/**
+			 * By default, the list will be empty when either no options are passed in,
+			 * or a user has typed a string that doesn't match any of the options. 
+			 * If you'd like to display a messsage instead when that occurs, pass it in here
+			 */
+			noResultsMessage: {
+				type: String,
+				default: ''
+			},
 			/** Generally, there's no need to set this via a prop - it will be set automatically when using v-model */
 			values: {
 				type: Array as PropType<SelectOption[]>,
@@ -116,6 +125,9 @@
 					// Used just for v-model, no need to subscribe to handle event
 					this.$emit('change', values)
 				}
+			},
+			displayNoResultsMessage(): boolean {
+				return this.noResultsMessage && (!this.filteredOptions || this.filteredOptions.length === 0)
 			}
 		},
 		updated() {
@@ -144,7 +156,7 @@
 
 				this.notificationMessage = !this.filteredOptions.length ? 'no results found' : ''
 
-				const menuState = this.filteredOptions.length > 0
+				const menuState = this.filteredOptions.length > 0 || this.noResultsMessage
 				if (this.open !== menuState) {
 					this.updateMenuState(menuState, false)
 				}
@@ -310,6 +322,9 @@
 					<slot name="option" :option="option">
 						{{  option.label }}
 					</slot>
+				</div>
+				<div v-if="displayNoResultsMessage" class="option-no-results">
+					<span>{{ noResultsMessage }}</span>
 				</div>
 			</div>
 			<svg class="combo-plus-icon" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" fill="currentColor">

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -350,6 +350,9 @@ $spacer: 1.875rem; // 30px
 				transform: translate(0, -50%) rotate(45deg);
 			}
 		}
+		.option-no-results {
+			padding: $option-padding;
+		}
 
 		.selected-options {
 			max-width: 100%;


### PR DESCRIPTION
When a user is typing into the multiselect, and their string does not return any options (or, when no options at all are passed in),
we normally just close the dropdown. After #39, we'll be notifying SR users that no results have been returned.
However, we also want consuming projects to be able to set a custom message about no results having been returned, to display visually; we do that here