### PR TITLE
Add method to handle focus shifting when selected pill is clicked

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -234,11 +234,11 @@
 			removeOptionAndHandleFocusShift(index: number) {
 				this.removeOption(index)
 				this.$nextTick(() => {
-				if (this.selectedOptions.length === 0) {
-					this.$refs.inputRef.focus()
-				} else {
-					this.$refs.selectedOptionPill[0].focus()
-				}
+					if (this.selectedOptions.length === 0) {
+						this.$refs.inputRef.focus()
+					} else {
+						this.$refs.selectedOptionPill[0].focus()
+					}
 				})
 			},
 			selectOption(option: SelectOption) {

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -29,6 +29,7 @@
 			inputRef: HTMLInputElement
 			listboxRef: HTMLElement
 			activeOptionRef: HTMLElement
+			selectedOptionPill: HTMLElement
 		}
 	}
 
@@ -230,6 +231,16 @@
 
 				setTimeout(() => { this.notificationMessage = '' }, 50)
 			},
+			removeOptionAndHandleFocusShift(index: number) {
+				this.removeOption(index)
+				this.$nextTick(() => {
+				if (this.selectedOptions.length === 0) {
+					this.$refs.inputRef.focus()
+				} else {
+					this.$refs.selectedOptionPill[0].focus()
+				}
+				})
+			},
 			selectOption(option: SelectOption) {
 				/**
 				 * emits the most recently selected value
@@ -269,11 +280,13 @@
 			<template v-for="(option, index) in selectedOptions" >
 				<li v-if="option.value" :key="option.value" >
 					<button
+						ref="selectedOptionPill"
 						class="selected-option-pill"
 						:disabled="disabled"
 						:aria-label="`remove ${option.label}`"
 						type="button"
-						@click="removeOption(index)"
+						:aria-describedby="`${htmlId}-selected-option-pills`"
+						@click="removeOptionAndHandleFocusShift(index)"
 					>
 						<!-- @slot Display the currently selected options via custom template code -->
 						<slot name="selectedOption" :option="option">


### PR DESCRIPTION
We know that NVDA does not announce the element focused in some instances (detailed here https://github.com/nvaccess/nvda/issues/5825#issuecomment-416523048)

Here is the NVDA/Firefox screenreader & focus shifting behavior:
![2020-10-29 11 08 39](https://user-images.githubusercontent.com/46361554/97592976-9ac1fe80-19d7-11eb-990c-c0253d0e9006.gif)

And Voiceover/Safari:
![2020-10-29 11 17 13](https://user-images.githubusercontent.com/46361554/97593908-829eaf00-19d8-11eb-8049-8d138032d214.gif)

