### PR TITLE
Add a watcher on loading to invoke opening the filter options

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -114,7 +114,16 @@
 				open: false,
 				inputValue: ''
 			} as ComponentData
-		},
+        },
+        watch: {
+            loading(newLoadingState, oldLoadingState): void {
+                // In cases where we move from a loading state, to a resolved state...
+                if (newLoadingState === false && oldLoadingState === true) {
+                    //... we want to open the options to show the newly fetched items.
+                    this.updateMenuState(true)
+                }
+            }
+        },
 		computed: {
 			activeId(): string {
 				return this.open ? `${this.htmlId}-${this.activeIndex}` : ''


### PR DESCRIPTION
Not 100% convinced by this, but I think there needs to be some solution for cases where we are fetching more options, and relying on the resolution of the promise to trigger an end to loading states. It is an odd user experience in Billie when you finish fetching options, the loading state resolves, and the user has no indication that new results are present. 

The other option would be to have consuming applications trigger a click? Or something? But that seems even more poopy. 