### PR TITLE
fix: Prevent 'select' event when no options

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -264,8 +264,10 @@
 				 * emits the most recently selected value
 				 * *generally not necessary*, if state can be handled w/ v-model alone
 				 */
-				this.$emit('select', option)
-				this.selectedOptions = [...this.selectedOptions, option]
+				if (option) {
+					this.$emit('select', option)
+					this.selectedOptions = [...this.selectedOptions, option]
+				}
 			},
 			updateOption(index: number) {
 				const option = this.filteredOptions[index]


### PR DESCRIPTION
Fix error when user trying  to select option from an empty options array (press enter after focusing and opening selectMulti with no options)
![image](https://user-images.githubusercontent.com/20156342/105999673-055e0580-60bf-11eb-8e97-5d51444523e9.png)
