### PR TITLE
fix: fix offsetHeight error when option is undefined

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -159,7 +159,7 @@
 				this.callFocus = false
 			}
 
-			if (this.open && isScrollable(this.$refs.listboxRef)) {
+			if (this.open && this.$refs?.activeOptionsRef?.[0] && isScrollable(this.$refs.listboxRef)) {
 				maintainScrollVisibility(this.$refs.activeOptionRef[0], this.$refs.listboxRef)
 			}
 		},


### PR DESCRIPTION
Fix offset height error when user trying select incorrect option
![image](https://user-images.githubusercontent.com/20156342/106002916-b74b0100-60c2-11eb-8964-f2bb13d09071.png)
