### PR TITLE
Adding labelField and valueField props to enable users to pass custom objects

### DIFF
--- a/docs/SelectMulti.stories.ts
+++ b/docs/SelectMulti.stories.ts
@@ -25,7 +25,7 @@ const Template = (args, { argTypes }) => ({
 			:disabled="disabled"
 			:displayPillsBelowInput="displayPillsBelowInput"
 			:noResultsMessage="noResultsMessage"
-			:valueField="valueField"
+			:uniqueIdField="uniqueIdField"
 	  	/>
 	</div>`
 });
@@ -41,7 +41,7 @@ Primary.args = {
 	disabled: false,
 	displayPillsBelowInput: false,
 	noResultsMessage: '',
-	valueField: 'value'
+	uniqueIdField: 'value'
 };
 
 
@@ -53,7 +53,7 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 	},
 	methods: {
 		getLabelForSearching(option: SelectOption): string {
-			return `label: ${option[this.labelField]}, with value: ${option[this.valueField]}`
+			return `label: ${option[this.labelField]}, with value: ${option[this.uniqueIdField]}`
 		}
 	},
 	template: `
@@ -71,10 +71,10 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 			:noResultsMessage="noResultsMessage"
 		>
 				<template v-slot:selectedOption="{ option }" >
-					<strong>{{ option[labelField] }}</strong> <em>{{ option[valueField] }}</em>
+					<strong>{{ option[labelField] }}</strong> <em>{{ option[uniqueIdField] }}</em>
 				</template>
 				<template v-slot:option="{ option }" >
-					<strong>label: {{ option[labelField] }}</strong>, <em>with value: {{ option[valueField] }}</em>
+					<strong>label: {{ option[labelField] }}</strong>, <em>with value: {{ option[uniqueIdField] }}</em>
 				</template>
 				<template v-slot:input-icon>
 					PLUS

--- a/docs/SelectMulti.stories.ts
+++ b/docs/SelectMulti.stories.ts
@@ -18,12 +18,14 @@ const Template = (args, { argTypes }) => ({
 			v-model="values"
 			:options="options"
 			:label="label"
+			:labelField="labelField"
 			:loading="loading"
 			:labelIsVisible="labelIsVisible"
 			:placeholder="placeholder"
 			:disabled="disabled"
 			:displayPillsBelowInput="displayPillsBelowInput"
 			:noResultsMessage="noResultsMessage"
+			:valueField="valueField"
 	  	/>
 	</div>`
 });
@@ -32,12 +34,14 @@ export const Primary = Template.bind({});
 Primary.args = {
 	label: 'My SelectMulti',
 	options: longDefaultListOfOptions,
+	labelField: 'label',
 	labelIsVisible: true,
 	loading: false,
 	placeholder: 'Select Options',
 	disabled: false,
 	displayPillsBelowInput: false,
-	noResultsMessage: ''
+	noResultsMessage: '',
+	valueField: 'value'
 };
 
 
@@ -49,7 +53,7 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 	},
 	methods: {
 		getLabelForSearching(option: SelectOption): string {
-			return `label: ${option.label}, with value: ${option.value}`
+			return `label: ${option[this.labelField]}, with value: ${option[this.valueField]}`
 		}
 	},
 	template: `
@@ -67,10 +71,10 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 			:noResultsMessage="noResultsMessage"
 		>
 				<template v-slot:selectedOption="{ option }" >
-					<strong>{{ option.label }}</strong> <em>{{ option.value }}</em>
+					<strong>{{ option[labelField] }}</strong> <em>{{ option[valueField] }}</em>
 				</template>
 				<template v-slot:option="{ option }" >
-					<strong>label: {{ option.label }}</strong>, <em>with value: {{ option.value }}</em>
+					<strong>label: {{ option[labelField] }}</strong>, <em>with value: {{ option[valueField] }}</em>
 				</template>
 				<template v-slot:input-icon>
 					PLUS

--- a/docs/SelectSingle.stories.ts
+++ b/docs/SelectSingle.stories.ts
@@ -21,7 +21,7 @@ const Template = (args, { argTypes }) => ({
 			:labelIsVisible="labelIsVisible"
 			:loading="loading"
 			:disabled="disabled"
-			:valueField="valueField"
+			:uniqueIdField="uniqueIdField"
 		/>
 	</div>`
 });
@@ -76,10 +76,10 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 			:disabled="disabled"
 		>
 			<template v-slot:selectedOption="{ option }" >
-				<strong>{{ option[labelField] }}</strong> <em>{{ option[valueField] }}</em>
+				<strong>{{ option[labelField] }}</strong> <em>{{ option[uniqueIdField] }}</em>
 			</template>
 			<template v-slot:option="{ option }" >
-				<strong>label: {{ option[labelField] }}</strong>, <em>with value: {{ option[valueField] }}</em>
+				<strong>label: {{ option[labelField] }}</strong>, <em>with value: {{ option[uniqueIdField] }}</em>
 			</template>
 		</SelectSingle>
 	</div>`

--- a/docs/SelectSingle.stories.ts
+++ b/docs/SelectSingle.stories.ts
@@ -17,9 +17,11 @@ const Template = (args, { argTypes }) => ({
 			v-model="value"
 			:options="options"
 			:label="label"
+			:labelField="labelField"
 			:labelIsVisible="labelIsVisible"
 			:loading="loading"
 			:disabled="disabled"
+			:valueField="valueField"
 		/>
 	</div>`
 });
@@ -74,10 +76,10 @@ const WithCustomOptionsTemplate = (args, { argTypes }) => ({
 			:disabled="disabled"
 		>
 			<template v-slot:selectedOption="{ option }" >
-				<strong>{{ option.label }}</strong> <em>{{ option.value }}</em>
+				<strong>{{ option[labelField] }}</strong> <em>{{ option[valueField] }}</em>
 			</template>
 			<template v-slot:option="{ option }" >
-				<strong>label: {{ option.label }}</strong>, <em>with value: {{ option.value }}</em>
+				<strong>label: {{ option[labelField] }}</strong>, <em>with value: {{ option[valueField] }}</em>
 			</template>
 		</SelectSingle>
 	</div>`

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -52,6 +52,14 @@
 				type: String,
 				required: true
 			},
+			/**
+			 * Field name in the `options` array that should be used for the label
+			 */
+			labelField: {
+				type: String,
+				required: false,
+				default: 'label'
+			},
 			loading: {
 				type: Boolean,
 				default: false
@@ -111,6 +119,14 @@
 				type: Array as PropType<SelectOption[]>,
 				required: false,
 				default: () => []
+			},
+			/**
+			 * Field name in the `options` array that should be used for the value
+			 */
+			valueField: {
+				type: String,
+				required: false,
+				default: 'value'
 			}
 		},
 		data() {
@@ -138,7 +154,7 @@
 				return this.open ? `${this.htmlId}-${this.activeIndex}` : ''
 			},
 			filteredOptions(): SelectOption[] {
-				return this.internalSearch ? filterOptions(this.options, this.inputValue, [], this.optionLabelForSearching) : this.options
+				return this.internalSearch ? filterOptions(this.options, this.inputValue,  this.labelField, [], this.optionLabelForSearching) : this.options
 			},
 			selectedOptions: {
 				get(): SelectOption[] {
@@ -298,19 +314,19 @@
 		</label>
 		<ul :id="`${htmlId}-selected`" class="selected-options" :class="{ 'below-input': displayPillsBelowInput }">
 			<template v-for="(option, index) in selectedOptions" >
-				<li v-if="option.value" :key="option.value" >
+				<li v-if="option[valueField]" :key="option[valueField]" >
 					<button
 						ref="selectedOptionPill"
 						class="selected-option-pill"
 						:disabled="disabled"
-						:aria-label="`remove ${option.label}`"
+						:aria-label="`remove ${option[labelField]}`"
 						type="button"
 						:aria-describedby="`${htmlId}-selected-option-pills`"
 						@click="removeOptionAndHandleFocusShift(index)"
 					>
 						<!-- @slot Display the currently selected options via custom template code -->
 						<slot name="selectedOption" :option="option">
-							{{  option.label }}
+							{{  option[labelField] }}
 						</slot>
 					</button>
 				</li>
@@ -351,7 +367,7 @@
 				<div
 					v-for="(option, index) in filteredOptions"
 					:id="`${htmlId}-${index}`"
-					:key="option.value"
+					:key="option[valueField]"
 					:ref="activeIndex === index ? 'activeOptionRef' : null"
 					:class="{
 						'option-current': activeIndex === index,
@@ -365,7 +381,7 @@
 				>
 					<!-- @slot Display individual options via custom template code -->
 					<slot name="option" :option="option">
-						{{  option.label }}
+						{{  option[labelField] }}
 					</slot>
 				</div>
 				<div v-if="displayNoResultsMessage" class="option-no-results">

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -53,7 +53,7 @@
 				required: true
 			},
 			/**
-			 * Field name in the `options` array that should be used for the label
+			 * Field name in the `options` array that should be used for displaying the label
 			 */
 			labelField: {
 				type: String,
@@ -121,9 +121,11 @@
 				default: () => []
 			},
 			/**
-			 * Field name in the `options` array that should be used for the value
+			 * Field name in the `options` array that should be used as the identifier for each option
+			 * Required in order to disambiguate between options, when indicating which options are selected, for example
+			 * default field: 'value'
 			 */
-			valueField: {
+			uniqueIdField: {
 				type: String,
 				required: false,
 				default: 'value'
@@ -314,7 +316,7 @@
 		</label>
 		<ul :id="`${htmlId}-selected`" class="selected-options" :class="{ 'below-input': displayPillsBelowInput }">
 			<template v-for="(option, index) in selectedOptions" >
-				<li v-if="option[valueField]" :key="option[valueField]" >
+				<li v-if="option[uniqueIdField]" :key="option[uniqueIdField]" >
 					<button
 						ref="selectedOptionPill"
 						class="selected-option-pill"
@@ -367,7 +369,7 @@
 				<div
 					v-for="(option, index) in filteredOptions"
 					:id="`${htmlId}-${index}`"
-					:key="option[valueField]"
+					:key="option[uniqueIdField]"
 					:ref="activeIndex === index ? 'activeOptionRef' : null"
 					:class="{
 						'option-current': activeIndex === index,

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -54,6 +54,7 @@
 			},
 			/**
 			 * Field name in the `options` array that should be used for displaying the label
+			 * Values in this field do not need to be unique - they are used for display only
 			 */
 			labelField: {
 				type: String,
@@ -121,9 +122,15 @@
 				default: () => []
 			},
 			/**
-			 * Field name in the `options` array that should be used as the identifier for each option
+			 * Field name in the `options` array that should be used as the **unique** identifier for each option
 			 * Required in order to disambiguate between options, when indicating which options are selected, for example
-			 * default field: 'value'
+			 * 
+			 * @example
+			 * ```
+			 * const options = [{ label: 'One', id: 1 }, { label: 'Two', id: 2 }]
+			 * 
+			 * <SelectMulti :options="options" uniqueIdField="id" />
+			 * ```
 			 */
 			uniqueIdField: {
 				type: String,

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -127,8 +127,9 @@
 			 * 
 			 * @example
 			 * ```
-			 * const options = [{ label: 'One', id: 1 }, { label: 'Two', id: 2 }]
-			 * 
+			 * options = [{ label: 'One', id: 1 },{ label: 'Two', id: 2 }]
+			 * ```
+			 * ```
 			 * <SelectMulti :options="options" uniqueIdField="id" />
 			 * ```
 			 */

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -43,6 +43,7 @@
 			},
 			/**
 			 * Field name in the `options` array that should be used for displaying the label
+			 * Values in this field do not need to be unique - they are used for display only
 			 */
 			labelField: {
 				type: String,
@@ -68,9 +69,15 @@
 				type: Object as PropType<SelectOption>
 			},
 		  	/**
-			 * Field name in the `options` array that should be used as the identifier for each option
-			 * Required in order to disambiguate between options, when indicating which option is selected, for example
-			 * default field: 'value'
+			 * Field name in the `options` array that should be used as the **unique** identifier for each option
+			 * Required in order to disambiguate between options, when indicating which options are selected, for example
+			 * 
+			 * @example
+			 * ```
+			 * const options = [{ label: 'One', id: 1 }, { label: 'Two', id: 2 }]
+			 * 
+			 * <SelectSingle :options="options" uniqueIdField="id" />
+			 * ```
 			 */
 			uniqueIdField: {
 				type: String,

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -41,6 +41,14 @@
 				type: String,
 				required: true
 			},
+			/**
+			 * Field name in the `options` array that should be used for the label
+			 */
+			labelField: {
+				type: String,
+				required: false,
+				default: 'label'
+			},
 			labelIsVisible: {
 				type: Boolean,
 				default: true
@@ -58,6 +66,14 @@
 				default: null,
 				required: false,
 				type: Object as PropType<SelectOption>
+			},
+		  /**
+			 * Field name in the `options` array that should be used for the value
+			 */
+			valueField: {
+				type: String,
+				required: false,
+				default: 'value'
 			}
 			// Potential props:
 			// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
@@ -67,7 +83,7 @@
 		},
 		data(): ComponentData {
 			const activeIndex = this.value
-				? this.options.findIndex(currentOption => currentOption.value == this.value.value)
+				? this.options.findIndex(currentOption => currentOption[this.valueField] == this.value[this.valueField])
 				: 0
 			return {
 				activeIndex,
@@ -201,7 +217,7 @@
 			},
 			selectOption(index: number) {
 				const selected = this.options[index]
-				this.inputValue = selected.label
+				this.inputValue = selected[this.labelField]
 				/**
 				 * emit the most recently selected value,
 				 * *generally not necessary*, if state can be handled w/ v-model alone
@@ -219,7 +235,7 @@
 			:class="{ 'sr-only': !labelIsVisible }"
 		>
 			{{ label }}
-			<span class="sr-only"> {{ value.label }}</span>
+			<span class="sr-only"> {{ value[labelField] }}</span>
 		</label>
 		<!-- aria-expanded is `open ? 'true' : 'false'` rather than `open` because the latter results in no attribute -->
 		<div
@@ -245,7 +261,7 @@
 				</slot>
 				<!-- @slot Display the currently selected option via custom template code -->
 				<slot v-else name="selectedOption" :option="value">
-					{{ value.label }}
+					{{ value[labelField] }}
 				</slot>
 			</span>
 		</div>
@@ -260,7 +276,7 @@
 			<div
 				v-for="(option, index) in options"
 				:id="`${htmlId}-item-${index}`"
-				:key="option.value.toString()"
+				:key="option[valueField].toString()"
 				class="combo-option"
 				:class="{
 					'option-selected': selectedIndex == index,
@@ -273,7 +289,7 @@
 			>
 				<!-- @slot Display individual options via custom template code -->
 				<slot name="option" :option="option">
-					{{ option.label }}
+					{{ option[labelField] }}
 				</slot>
 			</div>
 		</div>

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -114,7 +114,6 @@
 			}
 		},
 		methods: {
-			getIndexByLetter,
 			getSearchString(char: string) {
 				const multimatchTimeout = 500
 
@@ -193,7 +192,7 @@
 						this.updateMenuState(true)
 						const searchString = this.getSearchString(key)
 						return this.onOptionChange(
-							Math.max(0, this.getIndexByLetter(this.options, searchString))
+							Math.max(0, getIndexByLetter(this.options, searchString, this.labelField))
 						)
 					}
 					case MenuActions.Open:

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -74,8 +74,9 @@
 			 * 
 			 * @example
 			 * ```
-			 * const options = [{ label: 'One', id: 1 }, { label: 'Two', id: 2 }]
-			 * 
+			 * options = [{ label: 'One', id: 1 },{ label: 'Two', id: 2 }]
+			 * ```
+			 * ```
 			 * <SelectSingle :options="options" uniqueIdField="id" />
 			 * ```
 			 */

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -42,7 +42,7 @@
 				required: true
 			},
 			/**
-			 * Field name in the `options` array that should be used for the label
+			 * Field name in the `options` array that should be used for displaying the label
 			 */
 			labelField: {
 				type: String,
@@ -67,10 +67,12 @@
 				required: false,
 				type: Object as PropType<SelectOption>
 			},
-		  /**
-			 * Field name in the `options` array that should be used for the value
+		  	/**
+			 * Field name in the `options` array that should be used as the identifier for each option
+			 * Required in order to disambiguate between options, when indicating which option is selected, for example
+			 * default field: 'value'
 			 */
-			valueField: {
+			uniqueIdField: {
 				type: String,
 				required: false,
 				default: 'value'
@@ -83,7 +85,7 @@
 		},
 		data(): ComponentData {
 			const activeIndex = this.value
-				? this.options.findIndex(currentOption => currentOption[this.valueField] == this.value[this.valueField])
+				? this.options.findIndex(currentOption => currentOption[this.uniqueIdField] == this.value[this.uniqueIdField])
 				: 0
 			return {
 				activeIndex,
@@ -275,7 +277,7 @@
 			<div
 				v-for="(option, index) in options"
 				:id="`${htmlId}-item-${index}`"
-				:key="option[valueField].toString()"
+				:key="option[uniqueIdField].toString()"
 				class="combo-option"
 				:class="{
 					'option-selected': selectedIndex == index,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -42,6 +42,7 @@ export const enum MenuActions {
 export function filterOptions(
 	options: SelectOption[] = [],
 	filter: string,
+	labelField: string,
 	exclude: SelectOption[] = [],
 	optionLabelForSearching: null | ((option: SelectOption) => string) = null
 ): SelectOption[] {
@@ -49,8 +50,8 @@ export function filterOptions(
 		// NOTE: Changed from original implementation on sonder-ui:
 		// we want to match any instance of the current user string,
 		// rather than *only* when the user's string is at the beginning of an option
-		const label = optionLabelForSearching ? optionLabelForSearching(option) : option.label
-		const matches = label.toLowerCase().includes(filter.toLowerCase())
+		const label = optionLabelForSearching ? optionLabelForSearching(option) : option[labelField]
+		const matches = label?.toLowerCase().includes(filter.toLowerCase())
 
 		return matches && exclude.indexOf(option) < 0
 	})
@@ -132,7 +133,7 @@ export function getIndexByLetter(
 	startIndex = 0
 ): number {
 	const orderedOptions = [...options.slice(startIndex), ...options.slice(0, startIndex)]
-	const firstMatch = filterOptions(orderedOptions, filter)[0]
+	const firstMatch = filterOptions(orderedOptions, filter, this.labelField)[0]
 	const allSameLetter = (array: string[]) => array.every(letter => letter === array[0])
 
 	// first check if there is an exact match for the typed string
@@ -142,7 +143,7 @@ export function getIndexByLetter(
 
 	// if the same letter is being repeated, cycle through first-letter matches
 	else if (allSameLetter(filter.split(''))) {
-		const matches = filterOptions(orderedOptions, filter[0])
+		const matches = filterOptions(orderedOptions, filter[0], this.labelField)
 		return options.indexOf(matches[0])
 	}
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -130,10 +130,11 @@ export function getActionFromKey(
 export function getIndexByLetter(
 	options: SelectOption[],
 	filter: string,
-	startIndex = 0
+	labelField: string,
+	startIndex = 0,
 ): number {
 	const orderedOptions = [...options.slice(startIndex), ...options.slice(0, startIndex)]
-	const firstMatch = filterOptions(orderedOptions, filter, this.labelField)[0]
+	const firstMatch = filterOptions(orderedOptions, filter, labelField)[0]
 	const allSameLetter = (array: string[]) => array.every(letter => letter === array[0])
 
 	// first check if there is an exact match for the typed string
@@ -143,7 +144,7 @@ export function getIndexByLetter(
 
 	// if the same letter is being repeated, cycle through first-letter matches
 	else if (allSameLetter(filter.split(''))) {
-		const matches = filterOptions(orderedOptions, filter[0], this.labelField)
+		const matches = filterOptions(orderedOptions, filter[0], labelField)
 		return options.indexOf(matches[0])
 	}
 


### PR DESCRIPTION
ex: {id:1,text:'some label'}

### See original PR review here, all of which still applies: #53 

A huge thank you to @felixclement for the excellent work & great patience!

**Fresh branch, after `cherry-pick` from https://github.com/politico/vue-accessible-selects/pull/53/commits/32481963c7d4013699552037260ec5c182050a48 to avoid tricky indentation merge conflict resolutions**