### PR TITLE
Add optional chaining for checking key presence in getActionFromKey

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -95,7 +95,7 @@ export function getActionFromKey(
 	if (
 		key === Keys.Backspace ||
 		key === Keys.Clear ||
-		(key.length === 1 && key !== ' ' && !altKey && !ctrlKey && !metaKey)
+		(key?.length === 1 && key !== ' ' && !altKey && !ctrlKey && !metaKey)
 	) {
 		return MenuActions.Type
 	}


### PR DESCRIPTION
There may be cases when some non-standart keyboard key is pressed and we got error becuase of that
we can solve it by adding optional chaining here