### PR TITLE
Fix scroll jumping on mouse select

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -184,12 +184,13 @@
 				this.$refs.inputRef.focus()
 				this.callFocus = false
 			}
-
-			if (this.open && this.$refs?.activeOptionRef?.[0] && isScrollable(this.$refs.listboxRef)) {
-				maintainScrollVisibility(this.$refs.activeOptionRef[0], this.$refs.listboxRef)
-			}
 		},
 		methods: {
+			scrollOptionMenuIntoTheView() {
+				if (this.open && this.$refs?.activeOptionRef?.[0] && isScrollable(this.$refs.listboxRef)) {
+					maintainScrollVisibility(this.$refs.activeOptionRef[0], this.$refs.listboxRef)
+				}
+			},
 			onInput() {
 				const curValue = this.$refs.inputRef.value
 
@@ -219,7 +220,7 @@
 					this.updateMenuState(newMenuState, false)
 				}
 			},
-			onInputKeyDown(event: KeyboardEvent) {
+			async onInputKeyDown(event: KeyboardEvent) {
 				const max = this.filteredOptions.length - 1
 
 				const action = getActionFromKey(event, this.open)
@@ -230,7 +231,9 @@
 					case MenuActions.First:
 					case MenuActions.Previous:
 						event.preventDefault()
-						return this.onOptionChange(getUpdatedIndex(this.activeIndex, max, action))
+						this.onOptionChange(getUpdatedIndex(this.activeIndex, max, action))
+						await this.$nextTick()
+						return this.scrollOptionMenuIntoTheView()
 					case MenuActions.CloseSelect:
 						event.preventDefault()
 						return this.updateOption(this.activeIndex)


### PR DESCRIPTION
Prevent a scroll jumping when user selects options when option list out of the screen. In this fix I left a scrolling logic only for keyboard event. We can easily decline this pr if we want to save a scrolling on the mouse click.

how it worked before:

https://user-images.githubusercontent.com/44836424/148882268-592f9724-25f7-49a1-a976-96edc436eda0.mp4

after fix(no scrolling on mouse click):
https://user-images.githubusercontent.com/44836424/148882759-00aaf0a2-e6a7-47d9-9327-a5e1d52ef7c7.mp4


