### PR TITLE
fix (PROJ-3331): Change the color of placeholer

### DIFF
--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -3,7 +3,7 @@
 
 $default-primary-background-color: #eee;
 
-$default-placeholder-color: hsl(224, 8%, 47%);
+$default-placeholder-color: hsl(0, 0%, 0%);
 
 $default-selected-color: #fff;
 $default-selected-background-color: #444;


### PR DESCRIPTION
Change the placeholder font color from #6E7381 (VulcanGray47) to a more readable black (#000000)