### PR TITLE
fix (PROJ-4858): remove aria-labelledby due to duplicate reading results

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -356,7 +356,6 @@
 				:aria-expanded="`${open}`"
 				aria-haspopup="listbox"
 				aria-roledescription="Extended select list box"
-				:aria-labelledby="`${htmlId} ${htmlId}-selected`"
 				class="combo-input"
 				:disabled="disabled"
 				role="combobox"


### PR DESCRIPTION
Now screen readers won't read the results because we already have them above and can read them

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/19799724/203579176-d1350ac3-f85a-4940-baca-547ef8304e74.png">
