### PR TITLE
fix (PROJ-4858): remove aria-labelledby due to duplicate reading results

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -356,7 +356,6 @@
 				:aria-expanded="`${open}`"
 				aria-haspopup="listbox"
 				aria-roledescription="Extended select list box"
-				:aria-labelledby="`${htmlId} ${htmlId}-selected`"
 				class="combo-input"
 				:disabled="disabled"
 				role="combobox"


### PR DESCRIPTION
Now screen readers won't read the results because we already have them above and can read them

![image](https://user-images.githubusercontent.com/19799724/203592213-f6996b30-fd4b-454c-8e5e-de64a5491a66.png)
