### PR TITLE
fix (AIQ-3081): Aligns active element to bottom

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -48,7 +48,7 @@ export function ensureElementInViewport(elem: HTMLElement) {
 		&& rect.right <= (window.innerWidth || document.documentElement.clientWidth)
 
 	if (!isInView) {
-		elem.scrollIntoView()
+		elem.scrollIntoView(false)
 	}
 }
 


### PR DESCRIPTION
This will ensure active element is not hidden by header