### PR TITLE
fix(PROJ-6359): Label input element in SelectMulti

### DIFF
--- a/specs/SelectMulti.spec.ts
+++ b/specs/SelectMulti.spec.ts
@@ -63,5 +63,23 @@ describe('SelectMulti', () => {
 				expect(wrapper.vm['selectedOptions']).toEqual([{ label: 'Item Two', value: 'two' },{ label: 'Item Three', value: 'three' }])
 			})
 		})
+		describe('label functionality', () => {
+			it('adds the aria-labelledby attribute to the listbox', () => {
+				const options = [
+					{ label: 'Item One', value: 'one' },
+					{ label: 'Item Two', value: 'two' },
+					{ label: 'Item Three', value: 'three' }
+				]
+				wrapper = mount({
+					data() { 
+						return { selectedOptions: [], options }},
+					template: '<div><SelectMulti :options="options" v-model="selectedOptions" label="Sample SelectMulti" /></div>',
+					components: { SelectMulti }
+				})
+				const selectMulti = wrapper.findComponent(SelectMulti)
+				const input = selectMulti.find('input')
+				expect(Object.keys(input.attributes())).toContain('aria-labelledby')
+			})
+		})
 	})
 })

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -368,6 +368,7 @@
 				:aria-controls="`${htmlId}-listbox`"
 				:aria-expanded="`${open}`"
 				aria-haspopup="listbox"
+				:aria-labelledby="htmlId"
 				aria-roledescription="Extended select list box"
 				class="combo-input"
 				:disabled="disabled"


### PR DESCRIPTION
This pull request adds the aria-labelledby attribute to the input box in the MulltiSelect component.  I am making this change because screen readers do not currently read the label when the input box is selected.