### PR TITLE
cicd(PROJ-6359): Revert 1.8.6 bump due to build failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@politico/vue-accessible-selects",
-  "version": "1.8.6",
+  "version": "1.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@politico/vue-accessible-selects",
-      "version": "1.8.6",
+      "version": "1.8.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@politico/vue-accessible-selects",
-  "version": "1.8.6",
+  "version": "1.8.5",
   "description": "Select & Multi Select implementations for Vue, focused especially on implementing accessibility best practices",
   "files": [
     "dist",


### PR DESCRIPTION
When I ran `npm publish` for 1.8.6, I got a Typescript build error that prevented publishing.  I am reverting the version bump commit, and I will delete the 1.8.6 tag once this PR has been merged.

Once I figure out the build issue, I will do the version bump again.