### PR TITLE
(fix) PROJ-6359: add aria-placeholder attribute

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -376,6 +376,7 @@
 				type="text"
 				:value="inputValue"
 				:placeholder="placeholder"
+				:aria-placeholder="placeholder"
 				@blur="onInputBlur"
 				@click="updateMenuState(true)"
 				@input="onInput"


### PR DESCRIPTION
Adding an aria-labelledby attribute (https://github.com/politico/vue-accessible-selects/pull/121) introduced a bug where the Windows version of NVDA would read the combobox label, but it would no longer read the placeholder text.  This should fix that issue.

The bug may be related to [this weirdness in Windows a11y standards](https://www.davidmacd.com/blog/test-placeholder-text-aria-describedby.html).