### PR TITLE
feature (AIQ-4292): add straight aria-label for single select

### DIFF
--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -42,6 +42,10 @@
 			event: 'select'
 		},
 		props: {
+			ariaLabel: {
+				type: String,
+				default: ''
+			},
 			disabled: {
 				type: Boolean,
 				default: false
@@ -155,6 +159,9 @@
 			}
 		},
 		methods: {
+			ariaLabelValue(value, labelField) {
+				return this.ariaLabel.length > 0 ? this.ariaLabel : (value.screenReaderLabel || (value[labelField as keyof SelectOption] as string))
+			},
 			getSearchString(char: string) {
 				const multimatchTimeout = 500
 
@@ -294,7 +301,7 @@
 			:aria-disabled="isDisabledOrLoading"
 			:aria-expanded="open ? 'true' : 'false'"
 			aria-haspopup="listbox"
-			:aria-label="value.screenReaderLabel || (value[labelField as keyof SelectOption] as string)"
+			:aria-label="ariaLabelValue(value, labelField)"
 			:aria-labelledby="`${htmlId}-label`"
 			class="combo-input"
 			role="combobox"


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2023-09-05 at 18 40 09" src="https://github.com/politico/vue-accessible-selects/assets/100854412/cda3b5ac-e64c-4ec6-845b-de7fddc9860d">
