### PR TITLE
STM-4495: Added label slot for SelectMulti and SelectSingle

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -334,9 +334,11 @@
 
 <template>
 	<div class="vue-accessible-select-multi" :class="{ disabled, open }">
-		<label :id="htmlId" class="combo-label" :class="{ 'sr-only': !labelIsVisible }">
-			{{ label }}
-		</label>
+		<slot name="label">
+			<label :id="htmlId" class="combo-label" :class="{ 'sr-only': !labelIsVisible }">
+				{{ label }}
+			</label>
+		</slot>
 		<ul
 			:id="`${htmlId}-selected`"
 			:aria-labelledby="htmlId"

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -284,13 +284,15 @@
 </script>
 <template>
 	<div class="vue-accessible-select-single" :class="{ disabled: isDisabledOrLoading, open }">
-		<label
-			v-if="labelIsVisible"
-			:id="`${htmlId}-label`"
-			class="combo-label"
-		>
-			{{ label }}
-		</label>
+		<slot name="label">
+			<label
+				v-if="labelIsVisible"
+				:id="`${htmlId}-label`"
+				class="combo-label"
+			>
+				{{ label }}
+			</label>
+		</slot>
 		<!-- aria-expanded is `open ? 'true' : 'false'` rather than `open` because the latter results in no attribute -->
 		<div
 			:id="htmlId"


### PR DESCRIPTION
[STM-4495](https://politicollc.atlassian.net/browse/STM-4495): update SelectMulti component to add a slot for custom label

This PR is just a copy of https://github.com/politico/vue-accessible-selects/pull/132 for `next` branch to support vue3

[STM-4495]: https://politicollc.atlassian.net/browse/STM-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ