### PR TITLE
USPE-886. Make default plus icon not clickable

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -425,7 +425,7 @@
 				</div>
 			</slot>
 			</div>
-			<div class="combo-input-icon-block">
+			<div class="combo-input-icon-block" :class="{ 'not-clickable': !$slots['input-icon'] }">
 				<template v-if="!loading">
 					<slot name="input-icon">
 						<svg class="combo-plus-icon" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" fill="currentColor">

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -353,6 +353,10 @@ $spacer: 1.875rem; // 30px
 			top: 50%;
 			transform: translate(0, -50%);
 			right: math.div($spacer, 1.5);
+
+			&.not-clickable {
+				pointer-events: none;
+			}
 		}
 
 		.combo-plus-icon {


### PR DESCRIPTION
Since the default plus icon is not functional products decided to make this icon not clickable. 