### PR TITLE
bugfix (USPE-2966): Set screenreaderLabel to null if conditions aren't met

### DIFF
--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -159,7 +159,7 @@
 		},
 		methods: {
 			ariaLabelValue(value, labelField) {
-				return this.ariaLabel.length > 0 ? this.ariaLabel : (value.screenReaderLabel || (value[labelField as keyof SelectOption] as string) || null)
+				return this.ariaLabel.length > 0 ? (this.ariaLabel || null) : (value.screenReaderLabel || (value[labelField as keyof SelectOption] as string) || null)
 			},
 			getSearchString(char: string) {
 				const multimatchTimeout = 500

--- a/src/SelectSingle.vue
+++ b/src/SelectSingle.vue
@@ -159,7 +159,7 @@
 		},
 		methods: {
 			ariaLabelValue(value, labelField) {
-				return this.ariaLabel.length > 0 ? this.ariaLabel : (value.screenReaderLabel || (value[labelField as keyof SelectOption] as string))
+				return this.ariaLabel.length > 0 ? this.ariaLabel : (value.screenReaderLabel || (value[labelField as keyof SelectOption] as string) || null)
 			},
 			getSearchString(char: string) {
 				const multimatchTimeout = 500


### PR DESCRIPTION
sentry error found here: https://politico-tech.sentry.io/issues/5619591269/?alert_rule_id=6543512&alert_type=issue&notification_uuid=3467751e-b1da-4346-bfa1-4796c49df5e7&project=5770457&referrer=slack