### PR TITLE
chore: Add vue 2 support deprecation notice as post install message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # vue-accessible-selects
 
+> [!WARNING]
+> VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then, you can access this Vue 3-compatible version published as the alpha version of this package.
+
 [![npm version](https://badge.fury.io/js/@politico%2Fvue-accessible-selects.svg)](https://badge.fury.io/js/@politico%2Fvue-accessible-selects)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/dd8c8636-2b7a-4984-a031-712b57d9bfba/deploy-status)](https://app.netlify.com/sites/vue-accessible-selects/deploys)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepublishOnly": "npm test && npm run build && npm run shake",
     "shake": "agadoo dist/index.js",
     "storybook": "start-storybook -p 6006 --docs",
-    "build-storybook": "build-storybook --docs"
+    "build-storybook": "build-storybook --docs",
+    "postinstall": "echo 'VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then ,you can access this Vue 3-compatible version published as the alpha version of this package.'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "shake": "agadoo dist/index.js",
     "storybook": "start-storybook -p 6006 --docs",
     "build-storybook": "build-storybook --docs",
-    "postinstall": "echo 'VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then,you can access the Vue 3-compatible version published as the alpha version of this package.'"
+    "postinstall": "echo 'VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then, you can access the Vue 3-compatible version published as the alpha version of this package.'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "shake": "agadoo dist/index.js",
     "storybook": "start-storybook -p 6006 --docs",
     "build-storybook": "build-storybook --docs",
-    "postinstall": "echo 'VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then ,you can access this Vue 3-compatible version published as the alpha version of this package.'"
+    "postinstall": "echo 'VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then,you can access the Vue 3-compatible version published as the alpha version of this package.'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our alpha version supporting Vue 3 was first published in September of last year - we should now deprecate the Vue 2 version and publish the Vue 3 version as the primary/only version of our library.

Adding post-install output giving 3 month warning of deprecation of Vue 2 support:

> VUE 2 SUPPORT WILL BE DEPRECATED AFTER DECEMBER 2024. Beginning in January 2025, we will publish version 2 of the Vue Accessible Selects library, which is compatible with Vue 3. Until then ,you can access this Vue 3-compatible version published as the alpha version of this package.