### PR TITLE
fix (AIQ-5472): Update multiselect input click to toggle menu

### DIFF
--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -20,9 +20,10 @@
 		callFocus: boolean
 		htmlId: string
 		ignoreBlur: boolean
+		inputValue: string
 		notificationMessage: string
 		open: boolean
-		inputValue: string
+		ranOnInputBlur: boolean
 	}
 
 	interface ISelectMulti {
@@ -157,9 +158,10 @@
 				callFocus: false,
 				htmlId: uniqueId(),
 				ignoreBlur: false,
+				inputValue: '',
 				notificationMessage: '',
 				open: false,
-				inputValue: ''
+				ranOnInputBlur: false
 			} as ComponentData
         },
         watch: {
@@ -249,6 +251,11 @@
 					this.updateMenuState(newMenuState, false)
 				}
 			},
+			onIconClick() {
+				this.ranOnInputBlur ? null : this.updateMenuState(!this.open, !this.open)
+
+				this.ranOnInputBlur = false
+			},
 			onInputKeyDown(event: KeyboardEvent) {
 				const max = this.filteredOptions.length - 1
 
@@ -277,7 +284,8 @@
 					return
 				}
 
-				this.updateMenuState(false, false)
+				this.updateMenuState(!open, !open)
+				this.ranOnInputBlur = true
 			},
 			onOptionChange(index: number) {
 				this.activeIndex = index
@@ -295,6 +303,7 @@
 				this.updateOption(index)
 			},
 			onOptionMouseDown(event: MouseEvent) {
+				console.log('ran onOptionMouseDown')
 				this.ignoreBlur = true
 				this.callFocus = true
 				event.stopPropagation()
@@ -422,35 +431,35 @@
 				aria-multiselectable="true"
 				@mousedown="onMenuMouseDown"
 			>
-			<template v-if="filteredOptions">
-				<div
-					v-for="(option, index) in filteredOptions"
-					:id="`${htmlId}-${index}`"
-					:key="`${option[uniqueIdField as keyof SelectOption]}-${index}`"
-					:class="{
-						'option-current': activeIndex === index,
-						'option-selected': selectedOptions.indexOf(option) > -1,
-						'combo-option': true
-					}"
-					:aria-selected="selectedOptions.indexOf(option) > -1 ? true : false"
-					:aria-label="selectedOptions.indexOf(option) > -1 ? `${option.label} selected` : ''"
-					role="option"
-					@click="onOptionClick(index)"
-					@mousedown="onOptionMouseDown"
-				>
-					<!-- @slot Display individual options via custom template code -->
-					<slot name="option" :option="option">
-						{{  option[labelField as keyof SelectOption] }}
-					</slot>
-				</div>
-			</template>
-			<slot v-if="displayNoResultsMessage" name="no-results">
-				<div class="option-no-results">
-					<span>{{ noResultsMessage }}</span>
-				</div>
-			</slot>
+				<template v-if="filteredOptions">
+					<div
+						v-for="(option, index) in filteredOptions"
+						:id="`${htmlId}-${index}`"
+						:key="`${option[uniqueIdField as keyof SelectOption]}-${index}`"
+						:class="{
+							'option-current': activeIndex === index,
+							'option-selected': selectedOptions.indexOf(option) > -1,
+							'combo-option': true
+						}"
+						:aria-selected="selectedOptions.indexOf(option) > -1 ? true : false"
+						:aria-label="selectedOptions.indexOf(option) > -1 ? `${option.label} selected` : ''"
+						role="option"
+						@click="onOptionClick(index)"
+						@mousedown="onOptionMouseDown"
+					>
+						<!-- @slot Display individual options via custom template code -->
+						<slot name="option" :option="option">
+							{{  option[labelField as keyof SelectOption] }}
+						</slot>
+					</div>
+				</template>
+				<slot v-if="displayNoResultsMessage" name="no-results">
+					<div class="option-no-results">
+						<span>{{ noResultsMessage }}</span>
+					</div>
+				</slot>
 			</div>
-			<div @click="updateMenuState(true)" class="combo-input-icon-block">
+			<div @click="!open ? onIconClick() : null" class="combo-input-icon-block">
 				<template v-if="!loading">
 					<slot name="input-icon">
 						<svg class="combo-plus-icon" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" fill="currentColor">

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -406,7 +406,7 @@
 				:placeholder="placeholder"
 				:aria-placeholder="placeholder"
 				@blur="onInputBlur"
-				@click="updateMenuState(true)"
+				@click="updateMenuState(!open, !open)"
 				@input="onInput"
 				@keydown="onInputKeyDown"
 			/>

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -23,7 +23,6 @@
 		inputValue: string
 		notificationMessage: string
 		open: boolean
-		ranOnInputBlur: boolean
 	}
 
 	interface ISelectMulti {
@@ -161,7 +160,6 @@
 				inputValue: '',
 				notificationMessage: '',
 				open: false,
-				ranOnInputBlur: false
 			} as ComponentData
         },
         watch: {
@@ -251,11 +249,6 @@
 					this.updateMenuState(newMenuState, false)
 				}
 			},
-			onIconClick() {
-				this.ranOnInputBlur ? null : this.updateMenuState(!this.open, !this.open)
-
-				this.ranOnInputBlur = false
-			},
 			onInputKeyDown(event: KeyboardEvent) {
 				const max = this.filteredOptions.length - 1
 
@@ -279,13 +272,14 @@
 				}
 			},
 			onInputBlur() {
-				if (this.ignoreBlur) {
-					this.ignoreBlur = false
-					return
-				}
-
-				this.updateMenuState(!open, !open)
-				this.ranOnInputBlur = true
+				setTimeout(() => {
+					if (this.ignoreBlur) {
+						this.ignoreBlur = false
+						return
+					}
+	
+					this.updateMenuState(false, false)
+				}, 100)
 			},
 			onOptionChange(index: number) {
 				this.activeIndex = index
@@ -414,7 +408,7 @@
 				:placeholder="placeholder"
 				:aria-placeholder="placeholder"
 				@blur="onInputBlur"
-				@click="updateMenuState(!open, !open)"
+				@click="updateMenuState(true)"
 				@input="onInput"
 				@keydown="onInputKeyDown"
 			/>
@@ -458,7 +452,7 @@
 					</div>
 				</slot>
 			</div>
-			<div @click="!open ? onIconClick() : null" class="combo-input-icon-block">
+			<div @click="updateMenuState(!open, !open)" class="combo-input-icon-block">
 				<template v-if="!loading">
 					<slot name="input-icon">
 						<svg class="combo-plus-icon" viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" fill="currentColor">

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -272,6 +272,7 @@
 				}
 			},
 			onInputBlur() {
+				// To force onInputBlur run after updateMenuState we use setTimeout
 				setTimeout(() => {
 					if (this.ignoreBlur) {
 						this.ignoreBlur = false

--- a/src/SelectMulti.vue
+++ b/src/SelectMulti.vue
@@ -303,7 +303,6 @@
 				this.updateOption(index)
 			},
 			onOptionMouseDown(event: MouseEvent) {
-				console.log('ran onOptionMouseDown')
 				this.ignoreBlur = true
 				this.callFocus = true
 				event.stopPropagation()


### PR DESCRIPTION
## Description
Updates multiselect input and 'plus' icon click event to toggle menu state between open and closed.

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |
|    | :nail_care: Styling              |

## Updates

### Before
Clicking on the input or the 'plus' icon opens the menu, but does not close it upon a second click:
https://github.com/user-attachments/assets/03da37a5-f383-4f16-8bdb-ba3ab506d616


### After
Clicking on the input or the 'plus' icon toggles the menu state:
https://github.com/user-attachments/assets/428ac861-8e4e-41de-bffd-9e531a688ec4
